### PR TITLE
Add Documenter + Literate documentation

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,0 +1,29 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - master
+    tags: ['*']
+  pull_request:
+permissions:
+  actions: write
+  contents: write
+  pull-requests: read
+  statuses: write
+jobs:
+  build:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: julia-actions/setup-julia@fa02766e078afaaf09b14210362cee14137e6a32
+        with:
+          version: '1'
+      - uses: julia-actions/cache@a45e8fa8be21c18a06b7177052533149e61e9b38
+      - name: Install dependencies
+        run: julia --project=docs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
+      - name: Build and deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # authentication for same-repo deploys / PR previews
+          DOCUMENTER_KEY: ${{ secrets.DOCUMENTER_KEY }}  # SSH deploy key (preferred; enables fork PR previews)
+        run: julia --project=docs docs/make.jl

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ docs/site/
 # environment.
 Manifest.toml
 
+# Machine-specific preferences (e.g. written by Rfam.set_rfam_directory). These are
+# generated when running tests or building the docs and should not be committed.
+LocalPreferences.toml
+
 # built sysimage
 JuliaSysimage.so
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. The format 
 
 ## Unreleased
 
+- Added a documentation website built with [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and [Literate.jl](https://github.com/fredrikekre/Literate.jl).
+
 ## 3.2.0
 
 - The `RFAM_DIR` and `RFAM_VERSION` preferences can now be read from environment variables `ENV["JULIA_RFAM_DIR"]` and `ENV["JULIA_RFAM_VERSION"]`, if they exist. If the `LocalPreferences.toml` file is present specifying these values, it takes precedence and the environment variables will be ignored.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Rfam Julia package
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/Rfam.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/Rfam.jl/dev)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/Rfam.jl/stable/)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/Rfam.jl/dev/)
 
 Julia package to interface with the [Rfam](https://rfam.org) database.
 It downloads and caches Rfam data files locally, then returns their paths so

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Rfam Julia package
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://cossio.github.io/Rfam.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://cossio.github.io/Rfam.jl/dev)
+
 Julia package to interface with the [Rfam](https://rfam.org) database.
 It downloads and caches Rfam data files locally, then returns their paths so
 they can be consumed by other Julia packages and external tools.

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,0 +1,10 @@
+[deps]
+Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+FASTX = "c2308a5c-f048-11e8-3e8a-31650f418d12"
+Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Rfam = "38c5b72b-a3f0-437e-9f79-f3da4655de63"
+
+[compat]
+Documenter = "1"
+FASTX = "2"
+Literate = "2"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -15,6 +15,7 @@ Documenter.makedocs(
     modules = [Rfam],
     sitename = "Rfam.jl",
     authors = "Jorge Fernandez-de-Cossio-Diaz",
+    repo = Documenter.Remotes.GitHub("cossio", "Rfam.jl"),
     pages = [
         "Home" => "index.md",
         "Tutorial" => "literate/tutorial.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,0 +1,33 @@
+import Documenter
+import Literate
+import Rfam
+
+# Run Literate.jl over the tutorial sources, generating Markdown files next to
+# them. The generated `.md` files are git-ignored (see `.gitignore`).
+const literate_dir = joinpath(@__DIR__, "src", "literate")
+for file in readdir(literate_dir; join = true)
+    if endswith(file, ".jl")
+        Literate.markdown(file, literate_dir; documenter = true)
+    end
+end
+
+Documenter.makedocs(
+    modules = [Rfam],
+    sitename = "Rfam.jl",
+    authors = "Jorge Fernandez-de-Cossio-Diaz",
+    pages = [
+        "Home" => "index.md",
+        "Tutorial" => "literate/tutorial.md",
+        "Reference" => "reference.md",
+    ],
+    format = Documenter.HTML(;
+        prettyurls = get(ENV, "CI", "false") == "true",
+        canonical = "https://cossio.github.io/Rfam.jl/stable/",
+    ),
+)
+
+Documenter.deploydocs(
+    repo = "github.com/cossio/Rfam.jl.git",
+    devbranch = "master",
+    push_preview = true,
+)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,45 @@
+# Rfam.jl
+
+Julia package to interface with the [Rfam](https://rfam.org) database.
+It downloads and caches Rfam data files locally, then returns their paths so
+they can be consumed by other Julia packages and external tools.
+
+This package does not export any symbols; all functions are accessed through the
+`Rfam.` prefix.
+
+## Installation
+
+This package is registered. Install it with:
+
+```julia
+import Pkg
+Pkg.add("Rfam")
+```
+
+## Configuration
+
+Before using the download helpers, configure a local cache directory and the
+Rfam release to use:
+
+```julia
+import Rfam
+Rfam.set_rfam_directory("/path/to/rfam-data")
+Rfam.set_rfam_version("14.7")
+```
+
+These settings are stored in a `LocalPreferences.toml` file (via
+[Preferences.jl](https://github.com/JuliaPackaging/Preferences.jl)) and persist
+across Julia sessions. Alternatively, the package can be configured with the
+environment variables `JULIA_RFAM_DIR` and `JULIA_RFAM_VERSION`. Preference
+values take precedence over environment variables.
+
+## Contents
+
+```@contents
+Pages = ["literate/tutorial.md", "reference.md"]
+Depth = 2
+```
+
+## Related packages
+
+- [Infernal.jl](https://github.com/cossio/Infernal.jl)

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -37,10 +37,13 @@ fasta = Rfam.fasta_file("RF00162")
 
 isfile(fasta)
 
-# We can read it with [FASTX.jl](https://github.com/BioJulia/FASTX.jl):
+# We can read it with [FASTX.jl](https://github.com/BioJulia/FASTX.jl), using an
+# `open(...) do` block so the file handle is closed deterministically:
 
 import FASTX
-records = collect(FASTX.FASTA.Reader(open(fasta)))
+records = open(FASTX.FASTA.Reader, fasta) do reader
+    collect(reader)
+end
 length(records)
 
 # Let us look at the first record:

--- a/docs/src/literate/tutorial.jl
+++ b/docs/src/literate/tutorial.jl
@@ -1,0 +1,66 @@
+# # Tutorial
+#
+# This tutorial shows how to configure `Rfam.jl` and download data files from
+# the [Rfam](https://rfam.org) database.
+
+# ## Setup
+#
+# First we import the package.
+
+import Rfam
+
+# `Rfam.jl` caches all downloaded files inside a directory of our choosing, and
+# fetches files for a particular Rfam release. For this tutorial we use a
+# temporary directory and release `14.7`. In a real project you would point the
+# directory to a persistent location instead.
+
+Rfam.set_rfam_directory(mktempdir())
+Rfam.set_rfam_version("14.7")
+
+# We can query the current configuration at any time:
+
+Rfam.get_rfam_directory()
+
+#-
+
+Rfam.get_rfam_version()
+
+# ## Downloading a family FASTA file
+#
+# The function [`Rfam.fasta_file`](@ref) returns the local path to the FASTA
+# file of a given family, downloading and decompressing it on first use. Here we
+# fetch the SAM riboswitch family `RF00162`.
+
+fasta = Rfam.fasta_file("RF00162")
+
+# The returned value is a path to a file on disk:
+
+isfile(fasta)
+
+# We can read it with [FASTX.jl](https://github.com/BioJulia/FASTX.jl):
+
+import FASTX
+records = collect(FASTX.FASTA.Reader(open(fasta)))
+length(records)
+
+# Let us look at the first record:
+
+first(records)
+
+# Subsequent calls reuse the cached file instead of downloading it again, so
+# they return immediately.
+
+# ## Other data files
+#
+# The package provides similar helpers for the other files distributed by Rfam.
+# These download larger archives, so they are only listed here rather than
+# executed:
+#
+# ```julia
+# Rfam.cm()                  # path to `Rfam.cm` (covariance models)
+# Rfam.seed()                # path to `Rfam.seed` (seed alignments)
+# Rfam.clanin()              # path to `Rfam.clanin`
+# Rfam.seed_tree("RF00162")  # path to a family seed tree
+# ```
+#
+# See the [Reference](@ref) for the full list of available functions.

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -1,0 +1,41 @@
+# Reference
+
+```@meta
+CurrentModule = Rfam
+```
+
+This page documents all functions provided by `Rfam.jl`. None of them are
+exported, so they must be called with the `Rfam.` prefix.
+
+## Configuration
+
+```@docs
+Rfam.set_rfam_directory
+Rfam.get_rfam_directory
+Rfam.set_rfam_version
+Rfam.get_rfam_version
+```
+
+## Data files
+
+```@docs
+Rfam.fasta_file
+Rfam.cm
+Rfam.seed
+Rfam.clanin
+Rfam.seed_tree
+```
+
+## Paths and URLs
+
+```@docs
+Rfam.base_url
+Rfam.version_dir
+Rfam.fasta_dir
+```
+
+## Internal helpers
+
+```@docs
+Rfam.gunzip
+```


### PR DESCRIPTION
Sets up a documentation website using [Documenter.jl](https://github.com/JuliaDocs/Documenter.jl) and [Literate.jl](https://github.com/fredrikekre/Literate.jl), following the standard layout the repo was already primed for (`.gitignore` had `docs/build/` and `docs/src/literate/*.md`).

## What's included
- **`docs/make.jl`** — runs Literate over `docs/src/literate/*.jl`, builds the site, and deploys. `repo` is set explicitly so source links don't depend on remote auto-detection.
- **`docs/Project.toml`** — docs environment (`Documenter`, `Literate`, `FASTX`).
- **`docs/src/index.md`** — home page (overview, install, configuration).
- **`docs/src/literate/tutorial.jl`** — executed tutorial: configures the cache dir/version, downloads the `RF00162` FASTA, and reads it with FASTX.
- **`docs/src/reference.md`** — API reference with `@docs` blocks for all 13 documented functions.
- **`.github/workflows/Documentation.yml`** — builds & deploys docs on push to `master`, tags, and PRs. Reuses the same pinned action SHAs already in `ci.yml`.
- README documentation badges, CHANGELOG entry, and a `LocalPreferences.toml` ignore.

## Validation
Built locally with Julia 1.12.6 (`julia --project=docs docs/make.jl`) — exits 0 and renders `index.html`, `literate/tutorial.html`, `reference.html`. The `CheckDocument` stage confirms every docstring is included, and the tutorial executes end-to-end (downloads + parses the FASTA).

## Deploy key
The `DOCUMENTER_KEY` secret has been regenerated as a matched pair with a new read-write deploy key, so both Documenter deploys and TagBot tag-pushes work over SSH.

## Follow-up (manual)
After the first deploy creates the `gh-pages` branch, enable **Settings → Pages → Deploy from a branch → `gh-pages` / `(root)`** to serve the site at `https://cossio.github.io/Rfam.jl/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpP4A2B6T3pVCukdRAgwVS

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpP4A2B6T3pVCukdRAgwVS)_